### PR TITLE
Modifying refreshToken this.user to not broke the api

### DIFF
--- a/lib/grant.js
+++ b/lib/grant.js
@@ -255,7 +255,7 @@ function useRefreshTokenGrant (done) {
         'No user/userId parameter returned from getRefreshToken'));
     }
 
-    self.user = refreshToken.user || { id: refreshToken.userId };
+    self.user = refreshToken.user || refreshToken.userId;
 
     if (self.model.revokeRefreshToken) {
       return self.model.revokeRefreshToken(token, function (err) {


### PR DESCRIPTION
Modifying the object because it adds a {id: } before the user object, {id: } that is not added in saveAccessToken by default and it brokes the API