### PR TITLE
Correctly handle array of routes for a method in express 3

### DIFF
--- a/lib/oauth2server.js
+++ b/lib/oauth2server.js
@@ -213,7 +213,9 @@ OAuth2Server.prototype.lockdown = function (app) {
 
   if (app.routes) {
     for (var method in app.routes) {
-      app.routes[method].callbacks.forEach(lockdownExpress3);
+      app.routes[method].forEach(function (route) {
+        lockdownExpress3(route.callbacks);
+      });
     }
   } else {
     app._router.stack.forEach(lockdownExpress4);

--- a/lib/oauth2server.js
+++ b/lib/oauth2server.js
@@ -67,7 +67,7 @@ OAuth2Server.prototype.authorise = function () {
   var self = this;
 
   return function (req, res, next) {
-    new Authorise(self, req, next);
+    return new Authorise(self, req, next);
   };
 };
 

--- a/test/lockdown.js
+++ b/test/lockdown.js
@@ -86,4 +86,34 @@ describe('Lockdown pattern', function() {
       .get('/public')
       .expect(200, /hello/i, done);
   });
+
+  describe('in express 3', function () {
+    var app, privateAction, publicAction;
+
+    beforeEach(function () {
+      privateAction = function () {};
+      publicAction = function () {};
+
+      // mock express 3 app
+      app = {
+        routes: {
+          get: [
+            { callbacks: [ privateAction ] }
+          ]
+        }
+      };
+
+      app.oauth = oauth2server({ model: {} });
+      app.routes.get.push({ callbacks: [ app.oauth.bypass, publicAction ] })
+      app.oauth.lockdown(app);
+    });
+
+    it('adds authorise to non-bypassed routes', function () {
+      app.routes.get[0].callbacks[1].should.equal(privateAction);
+    });
+
+    it('removes oauth.bypass from bypassed routes', function () {
+      app.routes.get[1].callbacks[0].should.equal(publicAction);
+    });
+  });
 });

--- a/test/lockdown.js
+++ b/test/lockdown.js
@@ -96,14 +96,11 @@ describe('Lockdown pattern', function() {
 
       // mock express 3 app
       app = {
-        routes: {
-          get: [
-            { callbacks: [ privateAction ] }
-          ]
-        }
+        routes: { get: [] }
       };
 
       app.oauth = oauth2server({ model: {} });
+      app.routes.get.push({ callbacks: [ privateAction ] });
       app.routes.get.push({ callbacks: [ app.oauth.bypass, publicAction ] })
       app.oauth.lockdown(app);
     });

--- a/test/lockdown.js
+++ b/test/lockdown.js
@@ -20,6 +20,7 @@ var express = require('express'),
   should = require('should');
 
 var oauth2server = require('../');
+var Authorise = require('../lib/authorise');
 
 var bootstrap = function (oauthConfig) {
   var app = express();
@@ -105,7 +106,24 @@ describe('Lockdown pattern', function() {
       app.oauth.lockdown(app);
     });
 
+    function mockRequest(authoriseFactory) {
+      var req = {
+        get: function () {},
+        query: { access_token: { expires: null } }
+      };
+      var next = function () {};
+
+      app.oauth.model.getAccessToken = function (t, c) { c(null, t); };
+
+      return authoriseFactory(req, null, next);
+    }
+
     it('adds authorise to non-bypassed routes', function () {
+      var authorise = mockRequest(app.routes.get[0].callbacks[0]);
+      authorise.should.be.an.instanceOf(Authorise);
+    });
+
+    it('runs non-bypassed routes after authorise', function () {
       app.routes.get[0].callbacks[1].should.equal(privateAction);
     });
 


### PR DESCRIPTION
Was previously failing as follows because an array has no "callbacks" property.

```
oauth2-server/lib/oauth2server.js:217
  app.routes[method].callbacks.forEach(lockdownExpress3);
                                 ^
TypeError: Cannot call method 'forEach' of undefined
  at OAuth2Server.lockdown (oauth2-server/lib/oauth2server.js:217:36)
```