### PR TITLE
Ability to include extra data in oauth response

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -270,7 +270,7 @@ The spec does not actually require that you revoke the old token - hence this is
  - *mixed* **error**
    - Truthy to indicate an error
  - *mixed* **data**
-   - object or primitive to be placed into the response's `extra_data` field.
+   - object to merge into the grant response.
 
 ## Extension Grants
 You can support extension/custom grants by implementing the extendedGrant method as outlined above.

--- a/Readme.md
+++ b/Readme.md
@@ -260,6 +260,17 @@ The spec does not actually require that you revoke the old token - hence this is
      - *object* indicates a reissue (i.e. will not be passed to saveAccessToken/saveRefreshToken)
          - Must contain the following keys (if object):
            - *string* **accessToken** OR **refreshToken** dependant on type
+           
+#### getExtraData (user, client, callback)
+- *object* **user**
+ - the `user` object set by `getUser`
+- *object* **client**
+ - the `client` object set by `getClient`
+- *function* **callback (error, data)**
+ - *mixed* **error**
+   - Truthy to indicate an error
+ - *mixed* **data**
+   - object or primitive to be placed into the response's `extra_data` field.
 
 ## Extension Grants
 You can support extension/custom grants by implementing the extendedGrant method as outlined above.

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -432,26 +432,27 @@ function saveRefreshToken (done) {
 }
 
 /**
- *
+ * Fetch additional for response if model.getExtraData is defined.
  * @param done
  * @returns {*}
  */
-function getExtraData(done) {
-	var self = this;
+function getExtraData (done) {
+  var self = this;
 
-	if (typeof(this.model.getExtraData) === 'undefined') {
-		return done();
-	}
+  if (typeof(this.model.getExtraData) === 'undefined') {
+    this.extraData = {};
+    return done();
+  }
 
-	this.model.getExtraData(this.user, this.client, function (err, data) {
-		self.extraData = data;
+  this.model.getExtraData(this.user, this.client, function (err, data) {
+    self.extraData = data;
 
-		if (err) {
-			return done(error('server_error', false, err));
-		} else {
-			done();
-		}
-	});
+    if (err) {
+      return done(error('server_error', false, err));
+    } else {
+      done();
+    }
+  });
 }
 
 /**
@@ -472,8 +473,10 @@ function sendResponse (done) {
 
   if (this.refreshToken) response.refresh_token = this.refreshToken;
 
-  if (typeof(this.extraData) !== 'undefined') {
-	 response.extra_data = this.extraData;
+  for (attribute in this.extraData) {
+    if (this.extraData.hasOwnProperty(attribute)) {
+      response[attribute] = this.extraData[attribute];
+    }
   }
 
   this.res.jsonp(response);

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -35,6 +35,7 @@ var fns = [
   saveAccessToken,
   generateRefreshToken,
   saveRefreshToken,
+  getExtraData,
   sendResponse
 ];
 
@@ -431,6 +432,29 @@ function saveRefreshToken (done) {
 }
 
 /**
+ *
+ * @param done
+ * @returns {*}
+ */
+function getExtraData(done) {
+	var self = this;
+
+	if (typeof(this.model.getExtraData) === 'undefined') {
+		return done();
+	}
+
+	this.model.getExtraData(this.user, this.client, function (err, data) {
+		self.extraData = data;
+
+		if (err) {
+			return done(error('server_error', false, err));
+		} else {
+			done();
+		}
+	});
+}
+
+/**
  * Create an access token and save it with the model
  *
  * @param  {Function} done
@@ -447,6 +471,10 @@ function sendResponse (done) {
   }
 
   if (this.refreshToken) response.refresh_token = this.refreshToken;
+
+  if (typeof(this.extraData) !== 'undefined') {
+	 response.extra_data = this.extraData;
+  }
 
   this.res.jsonp(response);
 

--- a/test/grant.js
+++ b/test/grant.js
@@ -408,7 +408,7 @@ describe('Grant', function() {
               cb();
             },
             getExtraData: function (user, client, callback) {
-              callback(false, 'extraValue');
+              callback(false, {extraKey: 'extraValue'});
             }
           },
           grants: ['password']
@@ -423,9 +423,9 @@ describe('Grant', function() {
               if (err) return done(err);
 
               res.body.should.have.keys(['access_token', 'token_type', 'expires_in',
-                'extra_data']);
-              res.body.extra_data.should.be.instanceOf(String);
-              res.body.extra_data.should.equal('extraValue');
+                'extraKey']);
+              res.body.extraKey.should.be.instanceOf(String);
+              res.body.extraKey.should.equal('extraValue');
 
               done();
             });


### PR DESCRIPTION
Sometimes it is desirable to include extra data in a oauth grant response.  This PR provides the ability to grab extra data about a user/client and stuff it into the repsonse's `extra_data` key.