### PR TITLE
Add Redis example

### DIFF
--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -1,0 +1,19 @@
+# Redis Example
+
+A simple example with support for `password` and `refresh_token` grants using [Redis](http://redis.io/). You'll need [node-redis](https://github.com/mranney/node_redis) installed.
+
+## Usage
+
+```js
+app.oauth = oauthserver({
+  model: require('./model'),
+  grants: ['password', 'refresh_token'],
+  debug: true
+});
+```
+
+## Data model
+
+The example makes use of a simple data model where clients, tokens, refresh tokens and users are stored as [hashes](http://redis.io/topics/data-types#hashes). The allowed grants for each client are stored in a [set](http://redis.io/topics/data-types#sets) `clients:{id}:grant_types`. This allows grants to be added or removed dynamically. To simplify the user lookup users are identified by their username and not by a separate ID. Passwords are stored in the clear for simplicity, but in practice these should be hashed using a library like [bcrypt](https://github.com/ncb000gt/node.bcrypt.js).
+
+To inject some test data you can run the `testData.js` script in this directory. This will create a client with the ID `client` and secret `secret` and create a single user with the username `username` and password `password`.

--- a/examples/redis/index.js
+++ b/examples/redis/index.js
@@ -1,0 +1,31 @@
+var express = require('express'),
+  bodyParser = require('body-parser'),
+  oauthserver = require('../../'); // Would be: 'oauth2-server'
+
+var app = express();
+
+app.use(bodyParser());
+
+app.oauth = oauthserver({
+  model: require('./model'),
+  grants: ['password', 'refresh_token'],
+  debug: true
+});
+
+// Handle token grant requests
+app.all('/oauth/token', app.oauth.grant());
+
+app.get('/secret', app.oauth.authorise(), function (req, res) {
+  // Will require a valid access_token
+  res.send('Secret area');
+});
+
+app.get('/public', function (req, res) {
+  // Does not require an access_token
+  res.send('Public area');
+});
+
+// Error handling
+app.use(app.oauth.errorHandler());
+
+app.listen(3000);

--- a/examples/redis/model.js
+++ b/examples/redis/model.js
@@ -1,0 +1,97 @@
+var model = module.exports;
+var util = require('util');
+var redis = require('redis');
+var db = redis.createClient();
+
+var keys = {
+  token: 'tokens:%s',
+  client: 'clients:%s',
+  refreshToken: 'refresh_tokens:%s',
+  grantTypes: 'clients:%s:grant_types',
+  user: 'users:%s'
+};
+
+model.getAccessToken = function (bearerToken, callback) {
+  db.hgetall(util.format(keys.token, bearerToken), function (err, token) {
+    if (err) return callback(err);
+
+    if (!token) {
+      return callback();
+    }
+
+    callback(null, {
+      accessToken: token.accessToken,
+      clientId: token.clientId,
+      expires: new Date(token.expires),
+      userId: token.userId
+    });
+  });
+};
+
+model.getClient = function (clientId, clientSecret, callback) {
+  db.hgetall(util.format(keys.client, clientId), function (err, client) {
+    if (err) return callback(err);
+
+    if (!client || client.clientSecret !== clientSecret) {
+      return callback();
+    }
+
+    callback(null, {
+      clientId: client.clientId,
+      clientSecret: client.clientSecret
+    });
+  });
+};
+
+model.getRefreshToken = function (bearerToken, callback) {
+  db.hgetall(util.format(keys.refreshToken, bearerToken), function (err, token) {
+    if (err) return callback(err);
+
+    if (!token) {
+      return callback();
+    }
+
+    callback(null, {
+      refreshToken: token.accessToken,
+      clientId: token.clientId,
+      expires: new Date(token.expires),
+      userId: token.userId
+    });
+  });
+};
+
+model.grantTypeAllowed = function (clientId, grantType, callback) {
+  db.sismember(util.format(keys.grantTypes, clientId), grantType, callback);
+};
+
+model.saveAccessToken = function (accessToken, clientId, expires, user, callback) {
+  db.hmset(util.format(keys.token, accessToken), {
+    accessToken: accessToken,
+    clientId: clientId,
+    expires: expires.toISOString(),
+    userId: user.id
+  }, callback);
+};
+
+model.saveRefreshToken = function (refreshToken, clientId, expires, user, callback) {
+  db.hmset(util.format(keys.refreshToken, refreshToken), {
+    refreshToken: refreshToken,
+    clientId: clientId,
+    expires: expires.toISOString(),
+    userId: user.id
+  }, callback);
+};
+
+model.getUser = function (username, password, callback) {
+  db.hgetall(util.format(keys.user, username), function (err, user) {
+    if (err) return callback(err);
+
+    if (!user || password !== user.password) {
+      return callback();
+    }
+
+    callback(null, {
+      id: username
+    });
+  });
+};

--- a/examples/redis/model.js
+++ b/examples/redis/model.js
@@ -22,7 +22,7 @@ model.getAccessToken = function (bearerToken, callback) {
     callback(null, {
       accessToken: token.accessToken,
       clientId: token.clientId,
-      expires: new Date(token.expires),
+      expires: token.expires ? new Date(token.expires) : null,
       userId: token.userId
     });
   });
@@ -54,7 +54,7 @@ model.getRefreshToken = function (bearerToken, callback) {
     callback(null, {
       refreshToken: token.accessToken,
       clientId: token.clientId,
-      expires: new Date(token.expires),
+      expires: token.expires ? new Date(token.expires) : null,
       userId: token.userId
     });
   });
@@ -68,7 +68,7 @@ model.saveAccessToken = function (accessToken, clientId, expires, user, callback
   db.hmset(util.format(keys.token, accessToken), {
     accessToken: accessToken,
     clientId: clientId,
-    expires: expires.toISOString(),
+    expires: expires ? expires.toISOString() : null,
     userId: user.id
   }, callback);
 };
@@ -77,7 +77,7 @@ model.saveRefreshToken = function (refreshToken, clientId, expires, user, callba
   db.hmset(util.format(keys.refreshToken, refreshToken), {
     refreshToken: refreshToken,
     clientId: clientId,
-    expires: expires.toISOString(),
+    expires: expires ? expires.toISOString() : null,
     userId: user.id
   }, callback);
 };

--- a/examples/redis/testData.js
+++ b/examples/redis/testData.js
@@ -1,0 +1,27 @@
+#! /usr/bin/env node
+
+var db = require('redis').createClient();
+
+db.multi()
+  .hmset('users:username', {
+    id: 'username',
+    username: 'username',
+    password: 'password'
+  })
+  .hmset('clients:clientId', {
+    clientId: 'client',
+    clientSecret: 'secret'
+  })
+  .sadd('clients:clientId:grant_types', [
+    'password',
+    'refresh_token'
+  ])
+  .exec(function (errs) {
+    if (errs) {
+      console.error(errs[0].message);
+      return process.exit(1);
+    }
+
+    console.log('Client and user added successfully');
+    process.exit();
+  });

--- a/examples/redis/testData.js
+++ b/examples/redis/testData.js
@@ -8,11 +8,11 @@ db.multi()
     username: 'username',
     password: 'password'
   })
-  .hmset('clients:clientId', {
+  .hmset('clients:client', {
     clientId: 'client',
     clientSecret: 'secret'
   })
-  .sadd('clients:clientId:grant_types', [
+  .sadd('clients:client:grant_types', [
     'password',
     'refresh_token'
   ])


### PR DESCRIPTION
I've been using the server with [Redis](http://redis.io/) and thought I'd contribute a simple example. It currently supports the `password` and `refresh_token` grants, but if you think it's a useful example I can add in the methods needed for the remaining grant types.

I've added a simple `index.js` file borrowing the necessary bits from the [PostgreSQL example](https://github.com/thomseddon/node-oauth2-server/blob/master/examples/postgresql/index.js), but I noticed that not all of the examples have one so let me know if you think it's useful or not.

