### PR TITLE
Expose validated client for extended grant

### DIFF
--- a/lib/grant.js
+++ b/lib/grant.js
@@ -31,7 +31,7 @@ var fns = [
   checkClient,
   checkGrantTypeAllowed,
   checkGrantType,
-  exposeParams,
+  exposeUser,
   generateAccessToken,
   saveAccessToken,
   generateRefreshToken,
@@ -132,6 +132,7 @@ function credsFromBody (req) {
  * @this   OAuth
  */
 function checkClient (done) {
+  var self = this;
   this.model.getClient(this.client.clientId, this.client.clientSecret,
       function (err, client) {
     if (err) return done(error('server_error', false, err));
@@ -139,6 +140,9 @@ function checkClient (done) {
     if (!client) {
       return done(error('invalid_client', 'Client credentials are invalid'));
     }
+
+    // Expose validated client
+    self.req.oauth = { client: client };
 
     done();
   });
@@ -344,17 +348,12 @@ function checkGrantTypeAllowed (done) {
 }
 
 /**
- * Expose user and client params
+ * Expose user
  *
  * @param  {Function} done
  * @this   OAuth
  */
-function exposeParams (done) {
-  this.req.oauth = this.req.oauth || {};
-  this.req.oauth.client = {
-    id: this.client.clientId,
-    secret: this.client.clientSecret
-  };
+function exposeUser (done) {
   this.req.user = this.user;
 
   done();

--- a/test/grant.extended.js
+++ b/test/grant.extended.js
@@ -121,12 +121,14 @@ describe('Granting with extended grant type', function () {
     var app = bootstrap({
       model: {
         getClient: function (id, secret, callback) {
-          callback(false, true);
+          callback(false, { clientId: 'thom', clientSecret: 'nightworld' });
         },
         grantTypeAllowed: function (clientId, grantType, callback) {
           callback(false, true);
         },
         extendedGrant: function (grantType, req, callback) {
+          req.oauth.client.clientId.should.equal('thom');
+          req.oauth.client.clientSecret.should.equal('nightworld');
           callback(false, true, { id: 3 });
         },
         saveAccessToken: function () {

--- a/test/grant.js
+++ b/test/grant.js
@@ -256,7 +256,7 @@ describe('Grant', function() {
       var app = bootstrap({
         model: {
           getClient: function (id, secret, callback) {
-            callback(false, true);
+            callback(false, { clientId: 'thom', clientSecret: 'nightworld' });
           },
           grantTypeAllowed: function (clientId, grantType, callback) {
             callback(false, true);
@@ -265,8 +265,8 @@ describe('Grant', function() {
             callback(false, { id: 1 });
           },
           generateToken: function (type, req, callback) {
-            req.oauth.client.id.should.equal('thom');
-            req.oauth.client.secret.should.equal('nightworld');
+            req.oauth.client.clientId.should.equal('thom');
+            req.oauth.client.clientSecret.should.equal('nightworld');
             req.user.id.should.equal(1);
             callback(false, 'thommy');
           },


### PR DESCRIPTION
Preivously the extended grant function only had access the client credentials in the body, which could be different to the actual authenticated client. This fix exposes the authenticated credentials in req.oauth.client

Should fix #139 