### PR TITLE
error description should be in the 2nd parameter

### DIFF
--- a/lib/grant.js
+++ b/lib/grant.js
@@ -257,8 +257,7 @@ function useRefreshTokenGrant (done) {
     }
 
     if (!refreshToken.user && !refreshToken.userId) {
-      return done(error('server_error', false,
-        'No user/userId parameter returned from getRefreshToken'));
+      return done(error('server_error', 'No user/userId parameter returned from getRefreshToken'));
     }
 
     self.user = refreshToken.user || { id: refreshToken.userId };


### PR DESCRIPTION
found this issue when there is no description on the error thrown. turns out that the description is there, but in the incorrect parameter.