### PR TITLE
Added support for 'addToResponse' callback

### DIFF
--- a/lib/grant.js
+++ b/lib/grant.js
@@ -460,6 +460,13 @@ function sendResponse (done) {
     access_token: this.accessToken
   };
 
+  if (this.model.addToResponse) {
+    this.model.addToResponse(this.req, function (err, extraInfo) {
+      if (err) return callback(error('server_error', false, err));
+      if (extraInfo) response.extraInfo = extraInfo;
+    });
+  }
+
   if (this.config.accessTokenLifetime !== null) {
     response.expires_in = this.config.accessTokenLifetime;
   }


### PR DESCRIPTION
In some cases, one will like to sends extra information as apart of the response body. One
such case is auth resquests over weak\expensive connections, where one wants to get some
basic user information as part of response, instead of making a second call.