### PR TITLE
Include `expires_in`

### DIFF
--- a/lib/models/token-model.js
+++ b/lib/models/token-model.js
@@ -39,6 +39,10 @@ function TokenModel(data) {
   this.refreshTokenExpiresAt = data.refreshTokenExpiresAt;
   this.scope = data.scope;
   this.user = data.user;
+
+  if(this.accessTokenExpiresAt) {
+    this.accessTokenLifetime = Math.floor((this.accessTokenExpiresAt - new Date()) / 1000);
+  }
 }
 
 /**

--- a/test/unit/models/token-model_test.js
+++ b/test/unit/models/token-model_test.js
@@ -1,0 +1,26 @@
+var TokenModel = require('../../../lib/models/token-model');
+var sinon = require('sinon');
+
+/**
+ * Test `Server`.
+ */
+
+describe('Model', function() {
+  describe('constructor()', function() {
+    it('should calculate `accessTokenLifetime` if `accessTokenExpiresAt` is set', function() {
+      var atExpiresAt = new Date();
+      atExpiresAt.setHours(new Date().getHours() + 1);
+  
+      var data = {
+          accessToken: 'foo',
+          client: 'bar',
+          user: 'tar',
+          accessTokenExpiresAt: atExpiresAt
+      };
+  
+      var model = new TokenModel(data);
+      model.accessTokenLifetime.should.be.Number;
+      model.accessTokenLifetime.should.be.approximately(3600, 2);
+    });
+  });
+});


### PR DESCRIPTION
Recalculates and includes the `expires_in` value if `accessTokenExpiresAt` is available.
Found this approach to be both most straightforward and preferable to including the original `accessTokenLifetime` value, non-negligible time _might_ have transpired between generating the token and sending it to the client.

This closes #256.