### PR TITLE
Add model.validateScope to the grant flow

### DIFF
--- a/lib/grant-types/abstract-grant-type.js
+++ b/lib/grant-types/abstract-grant-type.js
@@ -4,6 +4,7 @@
  */
 
 var InvalidArgumentError = require('../errors/invalid-argument-error');
+var InvalidScopeError = require('../errors/invalid-scope-error');
 var Promise = require('bluebird');
 var is = require('../validator/is');
 var tokenUtil = require('../utils/token-util');
@@ -86,6 +87,20 @@ AbstractGrantType.prototype.getScope = function(request) {
   }
 
   return request.body.scope;
+};
+
+/**
+ * Validate requested scope.
+ */
+AbstractGrantType.prototype.validateScope = function(user, client, scope) {
+  return Promise.try(this.model.validateScope, [user, client, scope])
+    .then(function(scope) {
+      if(!scope) {
+        throw new InvalidScopeError('Invalid scope: Requested scope is invalid');
+      }
+
+      return scope;
+    });
 };
 
 /**

--- a/lib/grant-types/authorization-code-grant-type.js
+++ b/lib/grant-types/authorization-code-grant-type.js
@@ -183,13 +183,14 @@ AuthorizationCodeGrantType.prototype.revokeAuthorizationCode = function(code) {
 
 AuthorizationCodeGrantType.prototype.saveToken = function(user, client, authorizationCode, scope) {
   const fns = [
+    this.validateScope(user, client, scope),
     this.generateAccessToken(),
     this.generateRefreshToken()
   ];
 
   return Promise.all(fns)
     .bind(this)
-    .spread(function(accessToken, refreshToken) {
+    .spread(function(scope, accessToken, refreshToken) {
       var token = {
         accessToken: accessToken,
         authorizationCode: authorizationCode,

--- a/lib/grant-types/client-credentials-grant-type.js
+++ b/lib/grant-types/client-credentials-grant-type.js
@@ -84,13 +84,14 @@ ClientCredentialsGrantType.prototype.getUserFromClient = function(client) {
 
 ClientCredentialsGrantType.prototype.saveToken = function(user, client, scope) {
   var fns = [
+    this.validateScope(user, client, scope),
     this.generateAccessToken(),
     this.getAccessTokenExpiresAt()
   ];
 
   return Promise.all(fns)
     .bind(this)
-    .spread(function(accessToken, accessTokenExpiresAt) {
+    .spread(function(scope, accessToken, accessTokenExpiresAt) {
       var token = {
         accessToken: accessToken,
         accessTokenExpiresAt: accessTokenExpiresAt,

--- a/lib/grant-types/password-grant-type.js
+++ b/lib/grant-types/password-grant-type.js
@@ -102,6 +102,7 @@ PasswordGrantType.prototype.getUser = function(request) {
 
 PasswordGrantType.prototype.saveToken = function(user, client, scope) {
   var fns = [
+    this.validateScope(user, client, scope),
     this.generateAccessToken(),
     this.generateRefreshToken(),
     this.getAccessTokenExpiresAt(),
@@ -110,7 +111,7 @@ PasswordGrantType.prototype.saveToken = function(user, client, scope) {
 
   return Promise.all(fns)
     .bind(this)
-    .spread(function(accessToken, refreshToken, accessTokenExpiresAt, refreshTokenExpiresAt) {
+    .spread(function(scope, accessToken, refreshToken, accessTokenExpiresAt, refreshTokenExpiresAt) {
       var token = {
         accessToken: accessToken,
         accessTokenExpiresAt: accessTokenExpiresAt,

--- a/lib/handlers/authenticate-handler.js
+++ b/lib/handlers/authenticate-handler.js
@@ -37,8 +37,8 @@ function AuthenticateHandler(options) {
     throw new InvalidArgumentError('Missing parameter: `addAuthorizedScopesHeader`');
   }
 
-  if (options.scope && !options.model.validateScope) {
-    throw new InvalidArgumentError('Invalid argument: model does not implement `validateScope()`');
+  if (options.scope && !options.model.verifyScope) {
+    throw new InvalidArgumentError('Invalid argument: model does not implement `verifyScope()`');
   }
 
   this.addAcceptedScopesHeader = options.addAcceptedScopesHeader;
@@ -76,7 +76,7 @@ AuthenticateHandler.prototype.handle = function(request, response) {
         return;
       }
 
-      return this.validateScope(token);
+      return this.verifyScope(token);
     })
     .tap(function(token) {
       return this.updateResponse(response, token);
@@ -226,11 +226,11 @@ AuthenticateHandler.prototype.validateAccessToken = function(accessToken) {
 };
 
 /**
- * Validate scope.
+ * Verify scope.
  */
 
-AuthenticateHandler.prototype.validateScope = function(accessToken) {
-  return Promise.try(this.model.validateScope, [accessToken, this.scope]).then(function(scope) {
+AuthenticateHandler.prototype.verifyScope = function(accessToken) {
+  return Promise.try(this.model.verifyScope, [accessToken, this.scope]).then(function(scope) {
     if (!scope) {
       throw new InvalidScopeError('Invalid scope: scope is invalid');
     }

--- a/test/integration/grant-types/authorization-code-grant-type_test.js
+++ b/test/integration/grant-types/authorization-code-grant-type_test.js
@@ -115,7 +115,8 @@ describe('AuthorizationCodeGrantType integration', function() {
       var model = {
         getAuthorizationCode: function() { return { authorizationCode: 12345, client: { id: 'foobar' }, expiresAt: new Date(new Date() * 2), user: {} }; },
         revokeAuthorizationCode: function() { return { authorizationCode: 12345, client: { id: 'foobar' }, expiresAt: new Date(new Date() / 2), user: {} }; },
-        saveToken: function() { return token; }
+        saveToken: function() { return token; },
+        validateScope: function() { return 'foo'; }
       };
       var grantType = new AuthorizationCodeGrantType({ accessTokenLifetime: 123, model: model });
       var request = new Request({ body: { code: 12345 }, headers: {}, method: {}, query: {} });
@@ -464,7 +465,8 @@ describe('AuthorizationCodeGrantType integration', function() {
       var model = {
         getAuthorizationCode: function() {},
         revokeAuthorizationCode: function() {},
-        saveToken: function() { return token; }
+        saveToken: function() { return token; },
+        validateScope: function() { return 'foo'; }
       };
       var grantType = new AuthorizationCodeGrantType({ accessTokenLifetime: 123, model: model });
 

--- a/test/integration/grant-types/client-credentials-grant-type_test.js
+++ b/test/integration/grant-types/client-credentials-grant-type_test.js
@@ -94,7 +94,8 @@ describe('ClientCredentialsGrantType integration', function() {
       var token = {};
       var model = {
         getUserFromClient: function() { return {}; },
-        saveToken: function() { return token; }
+        saveToken: function() { return token; },
+        validateScope: function() { return 'foo'; }
       };
       var grantType = new ClientCredentialsGrantType({ accessTokenLifetime: 120, model: model });
       var request = new Request({ body: {}, headers: {}, method: {}, query: {} });
@@ -194,7 +195,8 @@ describe('ClientCredentialsGrantType integration', function() {
       var token = {};
       var model = {
         getUserFromClient: function() {},
-        saveToken: function() { return token; }
+        saveToken: function() { return token; },
+        validateScope: function() { return 'foo'; }
       };
       var grantType = new ClientCredentialsGrantType({ accessTokenLifetime: 123, model: model });
 

--- a/test/integration/grant-types/password-grant-type_test.js
+++ b/test/integration/grant-types/password-grant-type_test.js
@@ -95,10 +95,11 @@ describe('PasswordGrantType integration', function() {
       var token = {};
       var model = {
         getUser: function() { return {}; },
-        saveToken: function() { return token; }
+        saveToken: function() { return token; },
+        validateScope: function() { return 'baz'; }
       };
       var grantType = new PasswordGrantType({ accessTokenLifetime: 123, model: model });
-      var request = new Request({ body: { username: 'foo', password: 'bar' }, headers: {}, method: {}, query: {} });
+      var request = new Request({ body: { username: 'foo', password: 'bar', scope: 'baz' }, headers: {}, method: {}, query: {} });
 
       return grantType.handle(request, client)
         .then(function(data) {
@@ -269,7 +270,8 @@ describe('PasswordGrantType integration', function() {
       var token = {};
       var model = {
         getUser: function() {},
-        saveToken: function() { return token; }
+        saveToken: function() { return token; },
+        validateScope: function() { return 'foo'; }
       };
       var grantType = new PasswordGrantType({ accessTokenLifetime: 123, model: model });
 

--- a/test/integration/handlers/authenticate-handler_test.js
+++ b/test/integration/handlers/authenticate-handler_test.js
@@ -66,14 +66,14 @@ describe('AuthenticateHandler integration', function() {
       }
     });
 
-    it('should throw an error if `scope` was given and the model does not implement `validateScope()`', function() {
+    it('should throw an error if `scope` was given and the model does not implement `verifyScope()`', function() {
       try {
         new AuthenticateHandler({ addAcceptedScopesHeader: true, addAuthorizedScopesHeader: true, model: { getAccessToken: function() {} }, scope: 'foobar' });
 
         should.fail();
       } catch (e) {
         e.should.be.an.instanceOf(InvalidArgumentError);
-        e.message.should.equal('Invalid argument: model does not implement `validateScope()`');
+        e.message.should.equal('Invalid argument: model does not implement `verifyScope()`');
       }
     });
 
@@ -87,7 +87,7 @@ describe('AuthenticateHandler integration', function() {
     it('should set the `scope`', function() {
       var model = {
         getAccessToken: function() {},
-        validateScope: function() {}
+        verifyScope: function() {}
       };
       var grantType = new AuthenticateHandler({
         addAcceptedScopesHeader: true,
@@ -173,7 +173,7 @@ describe('AuthenticateHandler integration', function() {
         getAccessToken: function() {
           return accessToken;
         },
-        validateScope: function() {
+        verifyScope: function() {
           return true;
         }
       };
@@ -434,17 +434,17 @@ describe('AuthenticateHandler integration', function() {
     });
   });
 
-  describe('validateScope()', function() {
+  describe('verifyScope()', function() {
     it('should throw an error if `scope` is invalid', function() {
       var model = {
         getAccessToken: function() {},
-        validateScope: function() {
+        verifyScope: function() {
           return false;
         }
       };
       var handler = new AuthenticateHandler({ addAcceptedScopesHeader: true, addAuthorizedScopesHeader: true, model: model, scope: 'foo' });
 
-      return handler.validateScope('foo')
+      return handler.verifyScope('foo')
         .then(should.fail)
         .catch(function(e) {
           e.should.be.an.instanceOf(InvalidScopeError);
@@ -455,25 +455,25 @@ describe('AuthenticateHandler integration', function() {
     it('should support promises', function() {
       var model = {
         getAccessToken: function() {},
-        validateScope: function() {
+        verifyScope: function() {
           return true;
         }
       };
       var handler = new AuthenticateHandler({ addAcceptedScopesHeader: true, addAuthorizedScopesHeader: true, model: model, scope: 'foo' });
 
-      handler.validateScope('foo').should.be.an.instanceOf(Promise);
+      handler.verifyScope('foo').should.be.an.instanceOf(Promise);
     });
 
     it('should support non-promises', function() {
       var model = {
         getAccessToken: function() {},
-        validateScope: function() {
+        verifyScope: function() {
           return true;
         }
       };
       var handler = new AuthenticateHandler({ addAcceptedScopesHeader: true, addAuthorizedScopesHeader: true, model: model, scope: 'foo' });
 
-      handler.validateScope('foo').should.be.an.instanceOf(Promise);
+      handler.verifyScope('foo').should.be.an.instanceOf(Promise);
     });
   });
 
@@ -481,7 +481,7 @@ describe('AuthenticateHandler integration', function() {
     it('should not set the `X-Accepted-OAuth-Scopes` header if `scope` is not specified', function() {
       var model = {
         getAccessToken: function() {},
-        validateScope: function() {}
+        verifyScope: function() {}
       };
       var handler = new AuthenticateHandler({ addAcceptedScopesHeader: true, addAuthorizedScopesHeader: false, model: model });
       var response = new Response({ body: {}, headers: {} });
@@ -494,7 +494,7 @@ describe('AuthenticateHandler integration', function() {
     it('should set the `X-Accepted-OAuth-Scopes` header if `scope` is specified', function() {
       var model = {
         getAccessToken: function() {},
-        validateScope: function() {}
+        verifyScope: function() {}
       };
       var handler = new AuthenticateHandler({ addAcceptedScopesHeader: true, addAuthorizedScopesHeader: false, model: model, scope: 'foo bar' });
       var response = new Response({ body: {}, headers: {} });
@@ -507,7 +507,7 @@ describe('AuthenticateHandler integration', function() {
     it('should not set the `X-Authorized-OAuth-Scopes` header if `scope` is not specified', function() {
       var model = {
         getAccessToken: function() {},
-        validateScope: function() {}
+        verifyScope: function() {}
       };
       var handler = new AuthenticateHandler({ addAcceptedScopesHeader: false, addAuthorizedScopesHeader: true, model: model });
       var response = new Response({ body: {}, headers: {} });
@@ -520,7 +520,7 @@ describe('AuthenticateHandler integration', function() {
     it('should set the `X-Authorized-OAuth-Scopes` header', function() {
       var model = {
         getAccessToken: function() {},
-        validateScope: function() {}
+        verifyScope: function() {}
       };
       var handler = new AuthenticateHandler({ addAcceptedScopesHeader: false, addAuthorizedScopesHeader: true, model: model, scope: 'foo bar' });
       var response = new Response({ body: {}, headers: {} });

--- a/test/integration/handlers/token-handler_test.js
+++ b/test/integration/handlers/token-handler_test.js
@@ -269,7 +269,8 @@ describe('TokenHandler integration', function() {
       var model = {
         getClient: function() { return { grants: ['password'] }; },
         getUser: function() { return {}; },
-        saveToken: function() { return token; }
+        saveToken: function() { return token; },
+        validateScope: function() { return 'baz'; }
       };
       var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120 });
       var request = new Request({
@@ -278,7 +279,8 @@ describe('TokenHandler integration', function() {
           client_secret: 'secret',
           username: 'foo',
           password: 'bar',
-          grant_type: 'password'
+          grant_type: 'password',
+          scope: 'baz'
         },
         headers: { 'content-type': 'application/x-www-form-urlencoded', 'transfer-encoding': 'chunked' },
         method: 'POST',
@@ -616,6 +618,7 @@ describe('TokenHandler integration', function() {
           getAuthorizationCode: function() { return { authorizationCode: 12345, client: { id: 'foobar' }, expiresAt: new Date(new Date() * 2), user: {} }; },
           getClient: function() {},
           saveToken: function() { return token; },
+          validateScope: function() { return 'foo'; },
           revokeAuthorizationCode: function() { return { authorizationCode: 12345, client: { id: 'foobar' }, expiresAt: new Date(new Date() / 2), user: {} }; }
         };
         var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120 });
@@ -644,12 +647,14 @@ describe('TokenHandler integration', function() {
         var model = {
           getClient: function() {},
           getUserFromClient: function() { return {}; },
-          saveToken: function() { return token; }
+          saveToken: function() { return token; },
+          validateScope: function() { return 'foo'; }
         };
         var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120 });
         var request = new Request({
           body: {
-            grant_type: 'client_credentials'
+            grant_type: 'client_credentials',
+            scope: 'foo'
           },
           headers: {},
           method: {},
@@ -671,7 +676,8 @@ describe('TokenHandler integration', function() {
         var model = {
           getClient: function() {},
           getUser: function() { return {}; },
-          saveToken: function() { return token; }
+          saveToken: function() { return token; },
+          validateScope: function() { return 'baz'; }
         };
         var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120 });
         var request = new Request({
@@ -680,7 +686,8 @@ describe('TokenHandler integration', function() {
             client_secret: 'secret',
             grant_type: 'password',
             password: 'bar',
-            username: 'foo'
+            username: 'foo',
+            scope: 'baz'
           },
           headers: {},
           method: {},
@@ -731,7 +738,8 @@ describe('TokenHandler integration', function() {
         var model = {
           getClient: function() {},
           getUser: function() { return {}; },
-          saveToken: function() { return token; }
+          saveToken: function() { return token; },
+          validateScope: function() { return 'foo'; }
         };
         var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120, extendedGrantTypes: { 'urn:ietf:params:oauth:grant-type:saml2-bearer': PasswordGrantType } });
         var request = new Request({ body: { grant_type: 'urn:ietf:params:oauth:grant-type:saml2-bearer', username: 'foo', password: 'bar' }, headers: {}, method: {}, query: {} });

--- a/test/integration/server_test.js
+++ b/test/integration/server_test.js
@@ -159,10 +159,11 @@ describe('Server integration', function() {
         },
         saveToken: function() {
           return { accessToken: 1234, client: {}, user: {} };
-        }
+        },
+        validateScope: function() { return 'foo'; }
       };
       var server = new Server({ model: model });
-      var request = new Request({ body: { client_id: 1234, client_secret: 'secret', grant_type: 'password', username: 'foo', password: 'pass' }, headers: { 'content-type': 'application/x-www-form-urlencoded', 'transfer-encoding': 'chunked' }, method: 'POST', query: {} });
+      var request = new Request({ body: { client_id: 1234, client_secret: 'secret', grant_type: 'password', username: 'foo', password: 'pass', scope: 'foo' }, headers: { 'content-type': 'application/x-www-form-urlencoded', 'transfer-encoding': 'chunked' }, method: 'POST', query: {} });
       var response = new Response({ body: {}, headers: {} });
 
       return server.token(request, response)
@@ -203,10 +204,13 @@ describe('Server integration', function() {
         },
         saveToken: function() {
           return { accessToken: 1234, client: {}, user: {} };
+        },
+        validateScope: function() {
+            return 'foo';
         }
       };
       var server = new Server({ model: model });
-      var request = new Request({ body: { client_id: 1234, client_secret: 'secret', grant_type: 'password', username: 'foo', password: 'pass' }, headers: { 'content-type': 'application/x-www-form-urlencoded', 'transfer-encoding': 'chunked' }, method: 'POST', query: {} });
+      var request = new Request({ body: { client_id: 1234, client_secret: 'secret', grant_type: 'password', username: 'foo', password: 'pass', scope: 'foo' }, headers: { 'content-type': 'application/x-www-form-urlencoded', 'transfer-encoding': 'chunked' }, method: 'POST', query: {} });
       var response = new Response({ body: {}, headers: {} });
 
       server.token(request, response, null, next);

--- a/test/unit/grant-types/authorization-code-grant-type_test.js
+++ b/test/unit/grant-types/authorization-code-grant-type_test.js
@@ -66,6 +66,7 @@ describe('AuthorizationCodeGrantType', function() {
       };
       var handler = new AuthorizationCodeGrantType({ accessTokenLifetime: 120, model: model });
 
+      sinon.stub(handler, 'validateScope').returns('foobiz');
       sinon.stub(handler, 'generateAccessToken').returns(Promise.resolve('foo'));
       sinon.stub(handler, 'generateRefreshToken').returns(Promise.resolve('bar'));
 

--- a/test/unit/grant-types/client-credentials-grant-type_test.js
+++ b/test/unit/grant-types/client-credentials-grant-type_test.js
@@ -41,6 +41,7 @@ describe('ClientCredentialsGrantType', function() {
       };
       var handler = new ClientCredentialsGrantType({ accessTokenLifetime: 120, model: model });
 
+      sinon.stub(handler, 'validateScope').returns('foobar');
       sinon.stub(handler, 'generateAccessToken').returns('foo');
       sinon.stub(handler, 'getAccessTokenExpiresAt').returns('biz');
 

--- a/test/unit/grant-types/password-grant-type_test.js
+++ b/test/unit/grant-types/password-grant-type_test.js
@@ -43,6 +43,7 @@ describe('PasswordGrantType', function() {
       };
       var handler = new PasswordGrantType({ accessTokenLifetime: 120, model: model });
 
+      sinon.stub(handler, 'validateScope').returns('foobar');
       sinon.stub(handler, 'generateAccessToken').returns('foo');
       sinon.stub(handler, 'generateRefreshToken').returns('bar');
       sinon.stub(handler, 'getAccessTokenExpiresAt').returns('biz');

--- a/test/unit/handlers/authenticate-handler_test.js
+++ b/test/unit/handlers/authenticate-handler_test.js
@@ -92,19 +92,19 @@ describe('AuthenticateHandler', function() {
     });
   });
 
-  describe('validateScope()', function() {
+  describe('verifyScope()', function() {
     it('should call `model.getAccessToken()` if scope is defined', function() {
       var model = {
         getAccessToken: function() {},
-        validateScope: sinon.stub().returns(true)
+        verifyScope: sinon.stub().returns(true)
       };
       var handler = new AuthenticateHandler({ addAcceptedScopesHeader: true, addAuthorizedScopesHeader: true, model: model, scope: 'bar' });
 
-      return handler.validateScope('foo')
+      return handler.verifyScope('foo')
         .then(function() {
-          model.validateScope.callCount.should.equal(1);
-          model.validateScope.firstCall.args.should.have.length(2);
-          model.validateScope.firstCall.args[0].should.equal('foo', 'bar');
+          model.verifyScope.callCount.should.equal(1);
+          model.verifyScope.firstCall.args.should.have.length(2);
+          model.verifyScope.firstCall.args[0].should.equal('foo', 'bar');
         })
         .catch(should.fail);
     });


### PR DESCRIPTION
Currently, the only way of validating and/or filtering a requested scope is *within* the `model.saveToken` call itself.

This PR renames the present `model.validateScope` to `model.verifyScope` (as previously proposed by @night), and introduces a new `model.validateScope` method that is run before `model.saveToken`. In this manner, the grant flow can be aborted with an `InvalidScopeError` should that be necessary.


**Example**

```js
model.validateScope = (user, client, scope) => {
    // Check if this particular client may request the privileges in `scope`
    // Perform substitutions, filtering, etc. (e.g. foo:* -> foo:read foo:write)
    return sanitizedScope;
};

model.saveToken = (token, client, user) => {
    // token.scope is now `sanitizedScope`
    // Commit token to DB
    return token;
};
```